### PR TITLE
add getting started document to a hidden toctree

### DIFF
--- a/book/index.rst
+++ b/book/index.rst
@@ -9,6 +9,11 @@ and technical details.
 
     installation
 
+.. toctree::
+    :hidden:
+
+    getting_started
+
 TODO List
 ---------
 


### PR DESCRIPTION
The `getting_started.rst` document is not part of any toctree. To not display it publicly, I added it to a new hidden toctree.
