### PR TITLE
remove transition at the end of the file

### DIFF
--- a/cookbook/faq.rst
+++ b/cookbook/faq.rst
@@ -13,4 +13,3 @@ error "Parameters are not valid!", but in fact parameters are valid and SOAP API
   (f.e. ``rm /tmp/wsdl-*``); alternatively you can disable WSDL cache on PHP level in php.ini:
   ``soap.wsdl_cache_enabled=0``.
 
-------------


### PR DESCRIPTION
Having a transition at the end of the file is [no valid reStructuredText syntax](http://docutils.sourceforge.net/docs/user/rst/quickref.html#transitions).
