### PR TITLE
Correction for file path not matching namespace

### DIFF
--- a/book/customization.rst
+++ b/book/customization.rst
@@ -304,7 +304,7 @@ which ensures that the column is recognized properly.
 .. code-block:: php
     :linenos:
 
-    // src/Acme/DemoBundle/MigrationBundle/Schema/v1_0/AddCustomFieldMigration.php
+    // src/Acme/DemoBundle/Migrations/Schema/v1_0/AddCustomFieldMigration.php
     namespace Acme\DemoBundle\Migrations\Schema;
 
     use Doctrine\DBAL\Schema\Schema;

--- a/book/customization.rst
+++ b/book/customization.rst
@@ -305,7 +305,7 @@ which ensures that the column is recognized properly.
     :linenos:
 
     // src/Acme/DemoBundle/Migrations/Schema/v1_0/AddCustomFieldMigration.php
-    namespace Acme\DemoBundle\Migrations\Schema;
+    namespace Acme\DemoBundle\Migrations\Schema\v1_0;
 
     use Doctrine\DBAL\Schema\Schema;
     use Oro\Bundle\EntityExtendBundle\EntityConfig\ExtendScope;


### PR DESCRIPTION
If the file path doesn't match the namespace, the migration is not applied when a `php app/console oro:migration:load --force` is run