### PR TITLE
Fixed missing PHP extension zip

### DIFF
--- a/install_upgrade/installation_quick_start_dev/common-ce-1.rst
+++ b/install_upgrade/installation_quick_start_dev/common-ce-1.rst
@@ -114,7 +114,7 @@ Next, install PHP 7.1 and the required dependencies using the following command:
 
 .. code:: bash
 
-   yum install -y php-fpm php-cli php-pdo php-mysqlnd php-xml php-soap php-gd php-mbstring php-zip php-intl php-mcrypt php-opcache
+   yum install -y php-fpm php-cli php-pdo php-mysqlnd php-xml php-soap php-gd php-mbstring php-pecl-zip php-intl php-mcrypt php-opcache
 
 Install Composer
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The zip extension in remi repo is a pecl repo: _php-pecl-zip_. Bash command `$ yum search php71 | grep zip` returns `php71-php-pecl-zip.x86_64 : A ZIP archive management extension`.

TL;DR

Error appears during `composer install`:

```
]$ composer install --prefer-dist --no-dev
Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for oro/platform 3.1.3 -> satisfiable by oro/platform [3.1.3].
    - oro/platform 3.1.3 requires ext-zip * -> the requested PHP extension zip is missing from your system.
  Problem 2
    - oro/platform 3.1.3 requires ext-zip * -> the requested PHP extension zip is missing from your system.
    - oro/platform-serialised-fields 3.1.3 requires oro/platform ~3.1.1 -> satisfiable by oro/platform[3.1.3].
    - Installation request for oro/platform-serialised-fields 3.1.3 -> satisfiable by oro/platform-serialised-fields[3.1.3]
```