### PR TITLE
Bugfix/css output path for styles in assets.yml

### DIFF
--- a/frontend/storefront/css/index.rst
+++ b/frontend/storefront/css/index.rst
@@ -95,7 +95,7 @@ An example of the three folders structure (e.g., the *BundleName/Resources/views
             - 'bundles/oroui/blank/scss/variables/page-title-config.scss'
             - 'bundles/oroui/blank/scss/styles.scss'
         filters: ['cssrewrite', 'cssmin']
-        output: 'css/layout/blank/styles.css'
+        output: 'css/styles.css'
 
 Compiler collects all styles in one file for the theme. All files should be sorted by priority. There are files with a **settings folder** at the top followed by **variables** and all **styles.scss** at the end.
 

--- a/frontend/storefront/quick-start.rst
+++ b/frontend/storefront/quick-start.rst
@@ -56,7 +56,7 @@ Add Stylesheets with SCSS
        inputs:
            - bundles/demo/scss/logo.scss
            - bundles/demo/scss/settings/_colors.scss
-       output: css/layout/first_theme/styles.css
+       output: css/styles.css
 
 *  Run the ``bin/console oro:assets:build first_theme --watch`` command to process and combine SCSS files in  ``first_theme``.
 *  You can use SCSS source maps to find styles definition in a Browser and :ref:`Oro Frontend Stylebook <dev-doc-frontend-css-frontend-stylebook>` to check how updated styles affect the UI elements.


### PR DESCRIPTION
The previous one provided error with webpack like this one:

```

    ERROR in ./layout-build/dd/css/layout/digitaldrink/styles.css.scss
    Module build failed (from ../vendor/oro/platform/build/node_modules/mini-css-extract-plugin/dist/loader.js):
    ModuleBuildError: Module build failed (from ../vendor/oro/platform/build/node_modules/sass-loader/lib/loader.js):

    @import "./../../../bundles/oroui/blank/scss/settings/global-settings";
    ^
          File to import not found or unreadable: ./../../../bundles/oroui/blank/scss/settings/global-settings.
          in /Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/public/layout-build/dd/css/layout/digitaldrink/styles.css.scss (line 1, column 1)
        at /Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/webpack/lib/NormalModule.js:316:20
        at /Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/loader-runner/lib/LoaderRunner.js:367:11
        at /Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/loader-runner/lib/LoaderRunner.js:233:18
        at context.callback (/Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
        at Object.callback (/Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/sass-loader/lib/loader.js:52:13)
        at Object.done [as callback] (/Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/neo-async/async.js:8067:18)
        at options.error (/Users/sraye/Sites/hosts/digitaldrink/orocommerce/src/vendor/oro/platform/build/node_modules/node-sass/lib/index.js:294:32)
     @ ./layout-build/dd/css/layout/digitaldrink/styles.scss.js 1:0-27
```