### PR TITLE
Use the correct factory service

### DIFF
--- a/backend/extend-commerce/payment/index.rst
+++ b/backend/extend-commerce/payment/index.rst
@@ -388,7 +388,7 @@ To register the payment method view factory and provider, append the following k
 
    .. literalinclude:: /code_examples/commerce/payment_method/collect-on-delivery/Resources/config/services.yml
       :language: yaml
-      :lines: 41-53
+      :lines: 37-49
 
 
 


### PR DESCRIPTION
In documentation, we can see [the factory of the main method](https://doc.oroinc.com/backend/extend-commerce/payment/#add-the-payment-method-view-factory-and-provider-to-the-services-container) instead of the payment method view