### PR TITLE
Migration fixes

### DIFF
--- a/backend/setup/mysql-to-postgresql.rst
+++ b/backend/setup/mysql-to-postgresql.rst
@@ -29,6 +29,7 @@ is a sample migration config that can be used for this process:
    LOAD DATABASE
        FROM      mysql://dbuser:dbpass@localhost:3306/old_db_name
        INTO postgresql://dbuser:dbpass@localhost:5432/new_db_name
+       WITH prefetch rows = 10000
    alter schema 'old_db_name' rename to 'public'
    CAST type datetime to timestamp /*(DC2Type:datetime)*/ drop default drop not null using zero-dates-to-null,
    type int with extra auto_increment when (< precision 12) to serial drop typemod,

--- a/backend/setup/mysql-to-postgresql.rst
+++ b/backend/setup/mysql-to-postgresql.rst
@@ -32,6 +32,7 @@ is a sample migration config that can be used for this process:
        WITH prefetch rows = 10000
    alter schema 'old_db_name' rename to 'public'
    CAST type datetime to timestamp /*(DC2Type:datetime)*/ drop default drop not null using zero-dates-to-null,
+   type int with extra auto_increment to serial drop typemod,
    type int with extra auto_increment when (< precision 12) to serial drop typemod,
    type int with extra auto_increment when (>= 12 precision) to bigserial drop typemod,
    type int when (< precision 12) to int drop typemod,


### PR DESCRIPTION
Two updates to the pgloader configuration that appears in the MySQL to Postgresql migration guide:

* Add an extra typecast to ensure that signed int primary keys are converted correctly.  Where unsigned units are used as the primary key (4 audit tables and a handful of other core Oro tables), they converted correctly into a bigint + sequence.  But signed ints (the vast majority of tables) converted to ints with a primary key constraint and no sequence for autoincrementing.  Full credit to @AdamJHall for this fix, this was his work.  I've been able to test it and confirm it working.
* Limit the number of rows to prefetch to reduce heap usage.  This avoids a "Heap exhausted" error on conversion.  Given that Adam and I both had the same issue , and arrived at the same fix separately, this should probably be in the default config?

These two fixes are provided in separate commits so you can take or leave them individually. 